### PR TITLE
perf: added evm_snapshot in order to avoid deploying on beforeEach

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -34,6 +34,7 @@
     "@openzeppelin/contracts": "^3.3.0",
     "@openzeppelin/test-helpers": "^0.5.10",
     "eth-gas-reporter": "^0.2.22",
+    "ganache-time-traveler": "1.0.15",
     "hardhat": "^2.1.1",
     "hardhat-gas-reporter": "^1.0.1",
     "npm-run-all": "^4.1.5",

--- a/packages/contracts/test/CollSurplusPool.js
+++ b/packages/contracts/test/CollSurplusPool.js
@@ -1,5 +1,6 @@
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 const NonPayable = artifacts.require('NonPayable.sol')
 
 const th = testHelpers.TestHelper
@@ -27,7 +28,7 @@ contract('CollSurplusPool', async accounts => {
   const getOpenTroveLUSDAmount = async (totalDebt) => th.getOpenTroveLUSDAmount(contracts, totalDebt)
   const openTrove = async (params) => th.openTrove(contracts, params)
 
-  beforeEach(async () => {
+  before(async () => {
     contracts = await deploymentHelper.deployLiquityCore()
     contracts.troveManager = await TroveManagerTester.new()
     contracts.lusdToken = await LUSDToken.new(
@@ -45,6 +46,17 @@ contract('CollSurplusPool', async accounts => {
     await deploymentHelper.connectLQTYContracts(LQTYContracts)
     await deploymentHelper.connectLQTYContractsToCore(LQTYContracts, contracts)
   })
+
+  let snapshotId;
+
+  beforeEach(async() => {
+    let snapshot = await timeMachine.takeSnapshot();
+    snapshotId = snapshot['result'];
+  });
+
+  afterEach(async() => {
+      await timeMachine.revertToSnapshot(snapshotId);
+  });
 
   it("CollSurplusPool::getETH(): Returns the ETH balance of the CollSurplusPool after redemption", async () => {
     const ETH_1 = await collSurplusPool.getETH()

--- a/packages/contracts/test/GasCompensationTest.js
+++ b/packages/contracts/test/GasCompensationTest.js
@@ -1,5 +1,6 @@
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 const TroveManagerTester = artifacts.require("./TroveManagerTester.sol")
 const BorrowerOperationsTester = artifacts.require("./BorrowerOperationsTester.sol")
 const LUSDToken = artifacts.require("LUSDToken")
@@ -46,9 +47,6 @@ contract('Gas compensation tests', async accounts => {
 
     TroveManagerTester.setAsDeployed(troveManagerTester)
     BorrowerOperationsTester.setAsDeployed(borrowerOperationsTester)
-  })
-
-  beforeEach(async () => {
     contracts = await deploymentHelper.deployLiquityCore()
     contracts.troveManager = await TroveManagerTester.new()
     contracts.lusdToken = await LUSDToken.new(
@@ -57,7 +55,7 @@ contract('Gas compensation tests', async accounts => {
       contracts.borrowerOperations.address
     )
     const LQTYContracts = await deploymentHelper.deployLQTYContracts(bountyAddress, lpRewardsAddress, multisig)
-
+  
     priceFeed = contracts.priceFeedTestnet
     lusdToken = contracts.lusdToken
     sortedTroves = contracts.sortedTroves
@@ -66,11 +64,22 @@ contract('Gas compensation tests', async accounts => {
     stabilityPool = contracts.stabilityPool
     defaultPool = contracts.defaultPool
     borrowerOperations = contracts.borrowerOperations
-
+  
     await deploymentHelper.connectLQTYContracts(LQTYContracts)
     await deploymentHelper.connectCoreContracts(contracts, LQTYContracts) 
     await deploymentHelper.connectLQTYContractsToCore(LQTYContracts, contracts)
   })
+
+  let snapshotId;
+
+  beforeEach(async() => {
+    let snapshot = await timeMachine.takeSnapshot();
+    snapshotId = snapshot['result'];
+  });
+
+  afterEach(async() => {
+      await timeMachine.revertToSnapshot(snapshotId);
+  }); 
 
   // --- Raw gas compensation calculations ---
 

--- a/packages/contracts/test/GrowthTokenTest.js
+++ b/packages/contracts/test/GrowthTokenTest.js
@@ -1,5 +1,6 @@
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 
 const { keccak256 } = require('@ethersproject/keccak256');
 const { defaultAbiCoder } = require('@ethersproject/abi');
@@ -107,7 +108,7 @@ contract('LQTY Token', async accounts => {
     return { v, r, s, tx }
   }
 
-  beforeEach(async () => {
+  before(async () => {
     contracts = await deploymentHelper.deployLiquityCore()
     const LQTYContracts = await deploymentHelper.deployLQTYTesterContractsHardhat(bountyAddress, lpRewardsAddress, multisig)
 
@@ -123,6 +124,17 @@ contract('LQTY Token', async accounts => {
     await deploymentHelper.connectCoreContracts(contracts, LQTYContracts)
     await deploymentHelper.connectLQTYContractsToCore(LQTYContracts, contracts)
   })
+
+  let snapshotId;
+
+  beforeEach(async() => {
+    let snapshot = await timeMachine.takeSnapshot();
+    snapshotId = snapshot['result'];
+  });
+
+  afterEach(async() => {
+      await timeMachine.revertToSnapshot(snapshotId);
+  });
 
   it('balanceOf(): gets the balance of the account', async () => {
     await mintToABC()

--- a/packages/contracts/test/LQTYIssuanceArithmeticTest.js
+++ b/packages/contracts/test/LQTYIssuanceArithmeticTest.js
@@ -2,6 +2,7 @@ const Decimal = require("decimal.js");
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const { BNConverter } = require("../utils/BNConverter.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 const StabilityPool = artifacts.require("./StabilityPool.sol")
 
 const th = testHelpers.TestHelper
@@ -45,10 +46,6 @@ contract('LQTY community issuance arithmetic tests', async accounts => {
   const [bountyAddress, lpRewardsAddress, multisig] = accounts.slice(997, 1000)
 
   before(async () => {
-
-  })
-
-  beforeEach(async () => {
     contracts = await deploymentHelper.deployLiquityCore()
     const LQTYContracts = await deploymentHelper.deployLQTYTesterContractsHardhat(bountyAddress, lpRewardsAddress, multisig)
     contracts.stabilityPool = await StabilityPool.new()
@@ -64,6 +61,17 @@ contract('LQTY community issuance arithmetic tests', async accounts => {
     await deploymentHelper.connectCoreContracts(contracts, LQTYContracts)
     await deploymentHelper.connectLQTYContractsToCore(LQTYContracts, contracts)
   })
+
+  let snapshotId;
+
+  beforeEach(async() => {
+    let snapshot = await timeMachine.takeSnapshot();
+    snapshotId = snapshot['result'];
+  });
+
+  afterEach(async() => {
+      await timeMachine.revertToSnapshot(snapshotId);
+  });
 
   // Accuracy tests
   it("getCumulativeIssuanceFraction(): fraction doesn't increase if less than a minute has passed", async () => {

--- a/packages/contracts/test/LQTYStakingFeeRewardsTest.js
+++ b/packages/contracts/test/LQTYStakingFeeRewardsTest.js
@@ -2,6 +2,7 @@ const Decimal = require("decimal.js");
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const { BNConverter } = require("../utils/BNConverter.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 
 const LQTYStakingTester = artifacts.require('LQTYStakingTester')
 const TroveManagerTester = artifacts.require("TroveManagerTester")
@@ -45,7 +46,7 @@ contract('LQTYStaking revenue share tests', async accounts => {
 
   const openTrove = async (params) => th.openTrove(contracts, params)
 
-  beforeEach(async () => {
+  before(async () => {
     contracts = await deploymentHelper.deployLiquityCore()
     contracts.troveManager = await TroveManagerTester.new()
     contracts = await deploymentHelper.deployLUSDTokenTester(contracts)
@@ -69,6 +70,17 @@ contract('LQTYStaking revenue share tests', async accounts => {
     lqtyToken = LQTYContracts.lqtyToken
     lqtyStaking = LQTYContracts.lqtyStaking
   })
+
+  let revertToSnapshot;
+
+  beforeEach(async() => {
+    let snapshot = await timeMachine.takeSnapshot();
+    revertToSnapshot = () => timeMachine.revertToSnapshot(snapshot['result'])
+  });
+
+  afterEach(async() => {
+    await revertToSnapshot();
+  });
 
   it('stake(): reverts if amount is zero', async () => {
     // FF time one year so owner can transfer LQTY

--- a/packages/contracts/test/LUSDTokenTest.js
+++ b/packages/contracts/test/LUSDTokenTest.js
@@ -1,5 +1,6 @@
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 
 const { keccak256 } = require('@ethersproject/keccak256');
 const { defaultAbiCoder } = require('@ethersproject/abi');
@@ -64,7 +65,7 @@ contract('LUSDToken', async accounts => {
   let tokenVersion
 
   const testCorpus = ({ withProxy = false }) => {
-    beforeEach(async () => {
+    before(async () => {
 
       const contracts = await deploymentHelper.deployTesterContractsHardhat()
 
@@ -104,6 +105,17 @@ contract('LUSDToken', async accounts => {
         await lusdTokenOriginal.unprotectedMint(carol, 50)
       }
     })
+
+    let revertToSnapshot;
+
+    beforeEach(async() => {
+      let snapshot = await timeMachine.takeSnapshot();
+      revertToSnapshot = () => timeMachine.revertToSnapshot(snapshot['result'])
+    });
+
+    afterEach(async() => {
+      await revertToSnapshot();
+    });
 
     it('balanceOf(): gets the balance of the account', async () => {
       const aliceBalance = (await lusdTokenTester.balanceOf(alice)).toNumber()

--- a/packages/contracts/test/LiquitySafeMath128Test.js
+++ b/packages/contracts/test/LiquitySafeMath128Test.js
@@ -6,7 +6,7 @@ const LiquitySafeMath128Tester = artifacts.require("LiquitySafeMath128Tester")
 contract('LiquitySafeMath128Tester', async accounts => {
   let mathTester
 
-  beforeEach(async () => {
+  before(async () => {
     mathTester = await LiquitySafeMath128Tester.new()
   })
 

--- a/packages/contracts/test/PoolsTest.js
+++ b/packages/contracts/test/PoolsTest.js
@@ -4,6 +4,7 @@ const DefaultPool = artifacts.require("./DefaultPool.sol")
 const NonPayable = artifacts.require("./NonPayable.sol")
 
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 
 const th = testHelpers.TestHelper
 const dec = th.dec
@@ -18,12 +19,23 @@ contract('StabilityPool', async accounts => {
 
   const [owner, alice] = accounts;
 
-  beforeEach(async () => {
+  before(async () => {
     stabilityPool = await StabilityPool.new()
     const mockActivePoolAddress = (await NonPayable.new()).address
     const dumbContractAddress = (await NonPayable.new()).address
     await stabilityPool.setAddresses(dumbContractAddress, dumbContractAddress, mockActivePoolAddress, dumbContractAddress, dumbContractAddress, dumbContractAddress, dumbContractAddress)
   })
+
+  let revertToSnapshot;
+
+  beforeEach(async() => {
+    let snapshot = await timeMachine.takeSnapshot();
+    revertToSnapshot = () => timeMachine.revertToSnapshot(snapshot['result'])
+  });
+
+  afterEach(async() => {
+    await revertToSnapshot();
+  });
 
   it('getETH(): gets the recorded ETH balance', async () => {
     const recordedETHBalance = await stabilityPool.getETH()

--- a/packages/contracts/test/PriceFeedTest.js
+++ b/packages/contracts/test/PriceFeedTest.js
@@ -6,6 +6,7 @@ const MockTellor = artifacts.require("./MockTellor.sol")
 const TellorCaller = artifacts.require("./TellorCaller.sol")
 
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 const th = testHelpers.TestHelper
 
 const { dec, assertRevert, toBN } = th
@@ -22,7 +23,7 @@ contract('PriceFeed', async accounts => {
     await priceFeed.setAddresses(mockChainlink.address, tellorCaller.address, { from: owner })
   }
 
-  beforeEach(async () => {
+  before(async () => {
     priceFeedTestnet = await PriceFeedTestnet.new()
     PriceFeedTestnet.setAsDeployed(priceFeedTestnet)
 
@@ -55,6 +56,17 @@ contract('PriceFeed', async accounts => {
     await mockChainlink.setUpdateTime(now)
     await mockTellor.setUpdateTime(now)
   })
+
+  let revertToSnapshot;
+
+  beforeEach(async() => {
+    let snapshot = await timeMachine.takeSnapshot();
+    revertToSnapshot = () => timeMachine.revertToSnapshot(snapshot['result'])
+  });
+
+  afterEach(async() => {
+    await revertToSnapshot();
+  });
 
   describe('PriceFeed internal testing contract', async accounts => {
     it("fetchPrice before setPrice should return the default price", async () => {

--- a/packages/contracts/test/ProxyBorrowerWrappersScript.js
+++ b/packages/contracts/test/ProxyBorrowerWrappersScript.js
@@ -1,5 +1,6 @@
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 
 const TroveManagerTester = artifacts.require("TroveManagerTester")
 const LQTYTokenTester = artifacts.require("LQTYTokenTester")
@@ -60,7 +61,7 @@ contract('BorrowerWrappers', async accounts => {
   const getNetBorrowingAmount = async (debtWithFee) => th.getNetBorrowingAmount(contracts, debtWithFee)
   const openTrove = async (params) => th.openTrove(contracts, params)
 
-  beforeEach(async () => {
+  before(async () => {
     contracts = await deploymentHelper.deployLiquityCore()
     contracts.troveManager = await TroveManagerTester.new()
     contracts = await deploymentHelper.deployLUSDToken(contracts)
@@ -91,6 +92,17 @@ contract('BorrowerWrappers', async accounts => {
 
     LUSD_GAS_COMPENSATION = await borrowerOperations.LUSD_GAS_COMPENSATION()
   })
+
+  let revertToSnapshot;
+
+  beforeEach(async() => {
+    let snapshot = await timeMachine.takeSnapshot();
+    revertToSnapshot = () => timeMachine.revertToSnapshot(snapshot['result'])
+  });
+
+  afterEach(async() => {
+    await revertToSnapshot();
+  });
 
   it('proxy owner can recover ETH', async () => {
     const amount = toBN(dec(1, 18))

--- a/packages/contracts/test/StabilityPoolTest.js
+++ b/packages/contracts/test/StabilityPoolTest.js
@@ -1,5 +1,6 @@
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 const th = testHelpers.TestHelper
 const dec = th.dec
 const toBN = th.toBN
@@ -53,9 +54,6 @@ contract('StabilityPool', async accounts => {
 
     before(async () => {
       gasPriceInWei = await web3.eth.getGasPrice()
-    })
-
-    beforeEach(async () => {
       contracts = await deploymentHelper.deployLiquityCore()
       contracts.troveManager = await TroveManagerTester.new()
       contracts.lusdToken = await LUSDToken.new(
@@ -84,6 +82,17 @@ contract('StabilityPool', async accounts => {
 
       // Register 3 front ends
       await th.registerFrontEnds(frontEnds, stabilityPool)
+    })
+
+    let snapshotId;
+
+    beforeEach(async() => {
+      let snapshot = await timeMachine.takeSnapshot();
+      snapshotId = snapshot['result'];
+    });
+
+    afterEach(async() => {
+        await timeMachine.revertToSnapshot(snapshotId);
     })
 
     // --- provideToSP() ---

--- a/packages/contracts/test/StabilityPool_LQTYIssuanceTest.js
+++ b/packages/contracts/test/StabilityPool_LQTYIssuanceTest.js
@@ -1,5 +1,6 @@
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 
 const th = testHelpers.TestHelper
 const timeValues = testHelpers.TimeValues
@@ -48,7 +49,7 @@ contract('StabilityPool - LQTY Rewards', async accounts => {
   const openTrove = async (params) => th.openTrove(contracts, params)
   describe("LQTY Rewards", async () => {
 
-    beforeEach(async () => {
+    before(async () => {
       contracts = await deploymentHelper.deployLiquityCore()
       contracts.troveManager = await TroveManagerTester.new()
       contracts.lusdToken = await LUSDToken.new(
@@ -96,6 +97,17 @@ contract('StabilityPool - LQTY Rewards', async accounts => {
       issuance_M4 = toBN('46678287282156100').mul(communityLQTYSupply).div(toBN(dec(1, 18)))
       issuance_M5 = toBN('44093311972020200').mul(communityLQTYSupply).div(toBN(dec(1, 18)))
       issuance_M6 = toBN('41651488815552900').mul(communityLQTYSupply).div(toBN(dec(1, 18)))
+    })
+
+    let snapshotId;
+
+    beforeEach(async() => {
+      let snapshot = await timeMachine.takeSnapshot();
+      snapshotId = snapshot['result'];
+    });
+
+    afterEach(async() => {
+        await timeMachine.revertToSnapshot(snapshotId);
     })
 
     it("liquidation < 1 minute after a deposit does not change totalLQTYIssued", async () => {

--- a/packages/contracts/test/StabilityPool_SPWithdrawalTest.js
+++ b/packages/contracts/test/StabilityPool_SPWithdrawalTest.js
@@ -1,5 +1,6 @@
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 const TroveManagerTester = artifacts.require("./TroveManagerTester.sol")
 
 const { dec, toBN } = testHelpers.TestHelper
@@ -55,9 +56,6 @@ contract('StabilityPool - Withdrawal of stability deposit - Reward calculations'
 
     before(async () => {
       gasPriceInWei = await web3.eth.getGasPrice()
-    })
-
-    beforeEach(async () => {
       contracts = await deploymentHelper.deployLiquityCore()
       const LQTYContracts = await deploymentHelper.deployLQTYContracts(bountyAddress, lpRewardsAddress, multisig)
       contracts.troveManager = await TroveManagerTester.new()
@@ -75,6 +73,17 @@ contract('StabilityPool - Withdrawal of stability deposit - Reward calculations'
       await deploymentHelper.connectLQTYContracts(LQTYContracts)
       await deploymentHelper.connectCoreContracts(contracts, LQTYContracts)
       await deploymentHelper.connectLQTYContractsToCore(LQTYContracts, contracts)
+    })
+
+    let snapshotId;
+
+    beforeEach(async() => {
+      let snapshot = await timeMachine.takeSnapshot();
+      snapshotId = snapshot['result'];
+    });
+
+    afterEach(async() => {
+        await timeMachine.revertToSnapshot(snapshotId);
     })
 
     // --- Compounding tests ---

--- a/packages/contracts/test/StabilityPool_SPWithdrawalToCDPTest.js
+++ b/packages/contracts/test/StabilityPool_SPWithdrawalToCDPTest.js
@@ -1,5 +1,6 @@
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 const TroveManagerTester = artifacts.require("./TroveManagerTester.sol")
 
 const { dec, toBN } = testHelpers.TestHelper
@@ -57,7 +58,7 @@ contract('StabilityPool - Withdrawal of stability deposit - Reward calculations'
       gasPriceInWei = await web3.eth.getGasPrice()
     })
 
-    beforeEach(async () => {
+    before(async () => {
       contracts = await deploymentHelper.deployLiquityCore()
       const LQTYContracts = await deploymentHelper.deployLQTYContracts(bountyAddress, lpRewardsAddress, multisig)
       contracts.troveManager = await TroveManagerTester.new()
@@ -75,6 +76,17 @@ contract('StabilityPool - Withdrawal of stability deposit - Reward calculations'
       await deploymentHelper.connectLQTYContracts(LQTYContracts)
       await deploymentHelper.connectCoreContracts(contracts, LQTYContracts)
       await deploymentHelper.connectLQTYContractsToCore(LQTYContracts, contracts)
+    })
+
+    let snapshotId;
+
+    beforeEach(async() => {
+      let snapshot = await timeMachine.takeSnapshot();
+      snapshotId = snapshot['result'];
+    });
+
+    afterEach(async() => {
+        await timeMachine.revertToSnapshot(snapshotId);
     })
 
     // --- Compounding tests ---

--- a/packages/contracts/test/TroveManagerTest.js
+++ b/packages/contracts/test/TroveManagerTest.js
@@ -1,5 +1,7 @@
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
+
 const TroveManagerTester = artifacts.require("./TroveManagerTester.sol")
 const LUSDTokenTester = artifacts.require("./LUSDTokenTester.sol")
 
@@ -51,7 +53,7 @@ contract('TroveManager', async accounts => {
   const openTrove = async (params) => th.openTrove(contracts, params)
   const withdrawLUSD = async (params) => th.withdrawLUSD(contracts, params)
 
-  beforeEach(async () => {
+  before(async () => {
     contracts = await deploymentHelper.deployLiquityCore()
     contracts.troveManager = await TroveManagerTester.new()
     contracts.lusdToken = await LUSDTokenTester.new(
@@ -80,6 +82,17 @@ contract('TroveManager', async accounts => {
     await deploymentHelper.connectCoreContracts(contracts, LQTYContracts)
     await deploymentHelper.connectLQTYContracts(LQTYContracts)
     await deploymentHelper.connectLQTYContractsToCore(LQTYContracts, contracts)
+  })
+
+  let snapshotId;
+
+  beforeEach(async() => {
+    let snapshot = await timeMachine.takeSnapshot();
+    snapshotId = snapshot['result'];
+  });
+
+  afterEach(async() => {
+      await timeMachine.revertToSnapshot(snapshotId);
   })
 
   it('liquidate(): closes a Trove that has ICR < MCR', async () => {

--- a/packages/contracts/test/TroveManager_LiquidationRewardsTest.js
+++ b/packages/contracts/test/TroveManager_LiquidationRewardsTest.js
@@ -1,5 +1,6 @@
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 
 const th = testHelpers.TestHelper
 const dec = th.dec
@@ -37,7 +38,7 @@ contract('TroveManager - Redistribution reward calculations', async accounts => 
   const getNetBorrowingAmount = async (debtWithFee) => th.getNetBorrowingAmount(contracts, debtWithFee)
   const openTrove = async (params) => th.openTrove(contracts, params)
 
-  beforeEach(async () => {
+  before(async () => {
     contracts = await deploymentHelper.deployLiquityCore()
     contracts.troveManager = await TroveManagerTester.new()
     contracts.lusdToken = await LUSDToken.new(
@@ -61,6 +62,17 @@ contract('TroveManager - Redistribution reward calculations', async accounts => 
     await deploymentHelper.connectLQTYContracts(LQTYContracts)
     await deploymentHelper.connectCoreContracts(contracts, LQTYContracts)
     await deploymentHelper.connectLQTYContractsToCore(LQTYContracts, contracts)
+  })
+
+  let snapshotId;
+
+  beforeEach(async() => {
+    let snapshot = await timeMachine.takeSnapshot();
+    snapshotId = snapshot['result'];
+  });
+
+  afterEach(async() => {
+      await timeMachine.revertToSnapshot(snapshotId);
   })
 
   it("redistribution: A, B Open. B Liquidated. C, D Open. D Liquidated. Distributes correct rewards", async () => {

--- a/packages/contracts/test/TroveManager_RecoveryModeTest.js
+++ b/packages/contracts/test/TroveManager_RecoveryModeTest.js
@@ -1,5 +1,6 @@
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 
 const th = testHelpers.TestHelper
 const dec = th.dec
@@ -51,7 +52,7 @@ contract('TroveManager - in Recovery Mode', async accounts => {
   const getNetBorrowingAmount = async (debtWithFee) => th.getNetBorrowingAmount(contracts, debtWithFee)
   const openTrove = async (params) => th.openTrove(contracts, params)
 
-  beforeEach(async () => {
+  before(async () => {
     contracts = await deploymentHelper.deployLiquityCore()
     contracts.troveManager = await TroveManagerTester.new()
     contracts.lusdToken = await LUSDToken.new(
@@ -75,6 +76,17 @@ contract('TroveManager - in Recovery Mode', async accounts => {
     await deploymentHelper.connectLQTYContracts(LQTYContracts)
     await deploymentHelper.connectCoreContracts(contracts, LQTYContracts)
     await deploymentHelper.connectLQTYContractsToCore(LQTYContracts, contracts)
+  })
+
+  let snapshotId;
+
+  beforeEach(async() => {
+    let snapshot = await timeMachine.takeSnapshot();
+    snapshotId = snapshot['result'];
+  });
+
+  afterEach(async() => {
+      await timeMachine.revertToSnapshot(snapshotId);
   })
 
   it("checkRecoveryMode(): Returns true if TCR falls below CCR", async () => {

--- a/packages/contracts/test/Unipool.js
+++ b/packages/contracts/test/Unipool.js
@@ -3,6 +3,7 @@
 const { BN, time } = require('@openzeppelin/test-helpers');
 const { expect } = require('chai');
 const { TestHelper } = require('../utils/testHelpers.js');
+const timeMachine = require('ganache-time-traveler');
 
 const { assertRevert } = TestHelper;
 
@@ -75,9 +76,20 @@ contract('Unipool', function ([_, wallet1, wallet2, wallet3, wallet4, bountyAddr
   };
 
   describe('Unipool', async function () {
-    beforeEach(async function () {
+    before(async function () {
       await deploy(this);
       await this.pool.setParams(this.lqty.address, this.uni.address, this.DURATION);
+    });
+
+    let revertToSnapshot;
+
+    beforeEach(async() => {
+      let snapshot = await timeMachine.takeSnapshot();
+      revertToSnapshot = () => timeMachine.revertToSnapshot(snapshot['result'])
+    });
+
+    afterEach(async() => {
+      await revertToSnapshot();
     });
 
     it('Two stakers with the same stakes wait DURATION', async function () {

--- a/packages/contracts/test/stakeDeclineTest.js
+++ b/packages/contracts/test/stakeDeclineTest.js
@@ -1,5 +1,6 @@
 const deploymentHelper = require("../utils/deploymentHelpers.js")
 const testHelpers = require("../utils/testHelpers.js")
+const timeMachine = require('ganache-time-traveler');
 const TroveManagerTester = artifacts.require("./TroveManagerTester.sol")
 const LUSDTokenTester = artifacts.require("./LUSDTokenTester.sol")
 
@@ -48,7 +49,7 @@ contract('TroveManager', async accounts => {
     return ratio
   }
 
-  beforeEach(async () => {
+  before(async () => {
     contracts = await deploymentHelper.deployLiquityCore()
     contracts.troveManager = await TroveManagerTester.new()
     contracts.lusdToken = await LUSDTokenTester.new(
@@ -77,6 +78,17 @@ contract('TroveManager', async accounts => {
     await deploymentHelper.connectCoreContracts(contracts, LQTYContracts)
     await deploymentHelper.connectLQTYContracts(LQTYContracts)
     await deploymentHelper.connectLQTYContractsToCore(LQTYContracts, contracts)
+  })
+
+  let snapshotId;
+
+  beforeEach(async() => {
+    let snapshot = await timeMachine.takeSnapshot();
+    snapshotId = snapshot['result'];
+  });
+
+  afterEach(async() => {
+      await timeMachine.revertToSnapshot(snapshotId);
   })
 
   it("A given trove's stake decline is negligible with adjustments and tiny liquidations", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9878,6 +9878,11 @@ ganache-cli@^6.11.0:
     source-map-support "0.5.12"
     yargs "13.2.4"
 
+ganache-time-traveler@1.0.15:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/ganache-time-traveler/-/ganache-time-traveler-1.0.15.tgz#07c575abeb1e110903b76a2181e18598066617e9"
+  integrity sha512-3yoSbvvqSRA13w/SrNGy5tniwdwuRSAMrltGaOZAoqjnhpWkbVlGOVkdiEA/69dN4ZTArwJr1lWpiPzwqTWNCA==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"


### PR DESCRIPTION
# Description

The contracts tests take several minutes to run. This PR tries to tackle a low hanging fruit that helps improving such time.

## Proposed solution

In order to speed up the tests I've replaced several contracts deployment executions that were ran before each test by `buidlervm` `evm_snapshot` feature (it works on ganache as well).

At least on GH actions is taking `~25m` instead of the `~35m` seen on the main repo, leading to a 30% reduction